### PR TITLE
Overlap between two periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can pull the dependency from the central Maven repositories:
 
 ## Usage
 
-### Creating periods
+### Creating periods (`DateTimePeriod::make`)
 
 Create period with specific date-times and precision:
 
@@ -58,28 +58,9 @@ DateTimePeriod period = DateTimePeriod.make(
 );
 ```
 
-### Gap between two periods
-
-![](./docs/images/period-gap.svg)
-
-```java
-DateTimePeriod period1 = DateTimePeriod.make(
-        LocalDate.parse("2024-01-01"),
-        LocalDate.parse("2024-01-05")
-);
-
-DateTimePeriod period2 = DateTimePeriod.make(
-        LocalDate.parse("2024-01-10"),
-        LocalDate.parse("2024-01-31")
-);
-
-DateTimePeriod gap = period1.gapTo(period2);
-// gap represents [2024-01-06T00:00, 2024-01-09T00:00]
-```
-
 ### Operations
 
-#### Checking overlaps
+#### Checking overlaps (`DateTimePeriod::overlapsWith`)
 
 Check if two periods overlap:
 
@@ -97,7 +78,7 @@ DateTimePeriod midday = DateTimePeriod.make(
 boolean overlaps = morning.overlapsWith(midday); // returns true
 ```
 
-#### Checking adjacent periods
+#### Checking adjacent periods (`DateTimePeriod::touchesWith`)
 
 Check if two periods touch. two periods touch if the end of one period is exactly the start of the
 other.
@@ -144,7 +125,7 @@ DateTimePeriod period2 = DateTimePeriod.make(
 boolean touches = period1.touchesWith(period2); // returns false
 ```
 
-#### Renew
+#### Renew (`DateTimePeriod::renew`)
 
 ![](./docs/images/period-renew.svg)
 
@@ -161,7 +142,7 @@ DateTimePeriod renew = period.renew();
 // renew represents [2024-01-06T00:00, 2024-01-10T00:00]
 ```
 
-#### Checking time containment
+#### Checking time containment (`DateTimePeriod::contains`)
 
 Check if a period contains a specified point in time.
 
@@ -178,7 +159,7 @@ LocalDateTime evening = LocalDateTime.of(2024, 1, 1, 19, 0);
 boolean containsEvening = workday.contains(evening); // returns false
 ```
 
-#### Checking period containment
+#### Checking period containment (`DateTimePeriod::contains`)
 
 Checks if a period fully contains another period.
 
@@ -200,6 +181,44 @@ DateTimePeriod evening = DateTimePeriod.make(
         LocalDateTime.of(2024, 1, 1, 22, 0)
 );
 boolean containsEvening = workday.contains(evening); // returns false
+```
+
+### Gap between two periods (`DateTimePeriod::gap`)
+
+![](./docs/images/period-gap.svg)
+
+```java
+DateTimePeriod period1 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-01-05")
+);
+
+DateTimePeriod period2 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-10"),
+        LocalDate.parse("2024-01-31")
+);
+
+DateTimePeriod gap = period1.gap(period2);
+// gap represents [2024-01-06T00:00, 2024-01-09T00:00]
+```
+
+### Overlap between two periods (`DateTimePeriod::overlap`)
+
+![](./docs/images/period-overlap.svg)
+
+```java
+DateTimePeriod period1 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-05"),
+        LocalDate.parse("2024-01-20")
+);
+
+DateTimePeriod period2 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-01-15")
+);
+
+DateTimePeriod overlap = period1.overlap(period2);
+// overlap represents [2024-01-05T00:00, 2024-01-15T00:00]
 ```
 
 ### Testing

--- a/docs/images/period-overlap.svg
+++ b/docs/images/period-overlap.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 250">
+  <rect x="0" y="0" width="400" height="250" fill="white" />
+
+  <!-- Timeline -->
+  <line x1="20" y1="200" x2="350" y2="200" stroke="black" stroke-width="2"/>
+
+  <!-- Time markers -->
+  <line x1="20" y1="195" x2="20" y2="205" stroke="black" stroke-width="2"/>
+  <line x1="350" y1="195" x2="350" y2="205" stroke="black" stroke-width="2"/>
+
+  <!-- Period A -->
+  <rect x="100" y="35" width="200" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="110" y="55" font-family="Verdana" font-size="14" fill="white">Period A</text>
+
+  <!-- Period B -->
+  <rect x="20" y="85" width="260" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="30" y="105" font-family="Verdana" font-size="14" fill="white">Period B</text>
+
+  <!-- Overlap area -->
+  <rect x="100" y="185" width="180" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <text x="110" y="205" font-family="Verdana" font-size="14" fill="white">Overlap</text>
+
+  <!-- Overlap indicators -->
+  <line x1="100" y1="65" x2="100" y2="215" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="280" y1="65" x2="280" y2="215" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+
+  <!-- Legend -->
+  <text x="20" y="230" font-family="Verdana" font-size="12">Start</text>
+  <text x="330" y="230" font-family="Verdana" font-size="12">End</text>
+</svg>

--- a/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriod.java
+++ b/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriod.java
@@ -161,6 +161,26 @@ public class DateTimePeriod implements Serializable, Cloneable, Comparable<DateT
     }
 
     /**
+     * Returns a period that overlap with the given period and this period.
+     *
+     * @param period to check for overlap
+     * @return A new period representing the overlapping time, or null if there's no overlap
+     * @throws DateTimePeriodException if precision does not match
+     */
+    @Nullable public DateTimePeriod overlap(DateTimePeriod period) {
+        this.ensurePrecisionMatches(period);
+
+        LocalDateTime start = this.start().isAfter(period.start()) ? this.start() : period.start();
+        LocalDateTime end = period.end().isAfter(this.end()) ? this.end() : period.end();
+
+        if (start.isAfter(end)) {
+            return null;
+        }
+
+        return DateTimePeriod.make(start, end, this.precision());
+    }
+
+    /**
      * Checks if this period contains the specified point in time.
      *
      * @param localDateTime The LocalDateTime to check

--- a/src/test/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodTest.java
+++ b/src/test/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodTest.java
@@ -287,6 +287,36 @@ class DateTimePeriodTest {
         }
     }
 
+    @Nested
+    class Overlap {
+
+        @Test
+        void givenTwoPeriods_shouldDetermineOverlapBetweenThem() {
+            // Given
+            DateTimePeriod a = DateTimePeriod.make(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
+            DateTimePeriod b = DateTimePeriod.make(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 2, 29));
+
+            // When
+            DateTimePeriod result = a.overlap(b);
+
+            // Then
+            assertThat(result).isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 31)));
+        }
+
+        @Test
+        void shouldReturnNull_whenTwoPeriodsDoNotOverlap() {
+            // Given
+            DateTimePeriod a = DateTimePeriod.make(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 5));
+            DateTimePeriod b = DateTimePeriod.make(LocalDate.of(2024, 5, 15), LocalDate.of(2024, 5, 20));
+
+            // When
+            DateTimePeriod result = a.overlap(b);
+
+            // Then
+            assertThat(result).isNull();
+        }
+    }
+
     @Test
     void toString_shouldContainsStartAndEnd() {
         assertThat(DateTimePeriod.make(LocalDate.of(2024, 1, 10), LocalDate.of(2024, 1, 15))


### PR DESCRIPTION
## Description

Add functionality to calculate the overlap between two `DateTimePeriod` instances, returning a new `DateTimePeriod` representing the interval between them.

## Implementation

- New method to calculate the overlap between two periods
- Throws `DateTimePeriodException` when the precision does not match
- Returns `null` if periods do not overlap

## Usage Example

```java
DateTimePeriod period1 = DateTimePeriod.make(
        LocalDate.parse("2024-01-05"),
        LocalDate.parse("2024-01-20")
);

DateTimePeriod period2 = DateTimePeriod.make(
        LocalDate.parse("2024-01-01"),
        LocalDate.parse("2024-01-15")
);

DateTimePeriod overlap = period1.overlap(period2);
// overlap represents [2024-01-05T00:00, 2024-01-15T00:00]
```
