### PR TITLE
Overlap of all periods across collections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to `datetimeperiod` will be documented in this file
 ## 0.1.0 - 202X-XX-XX
 
 - Initial test release
+

--- a/README.md
+++ b/README.md
@@ -280,6 +280,79 @@ DateTimePeriod overlapAny = period1.overlapAny(period2, period3);
 
 ---
 
+The `DateTimePeriodCollection` methods:
+
+### Creating collections
+
+Create a new collection from the given periods:
+
+```java
+DateTimePeriod period = DateTimePeriod.make(
+        LocalDateTime.of(2024, 1, 1, 9, 30),
+        LocalDateTime.of(2024, 1, 1, 17, 45),
+        Precision.MINUTE
+);
+
+DateTimePeriodCollection collection = DateTimePeriodCollection.of(period, period);
+```
+
+Create a new collection from the given `Collection` of periods.
+
+```java
+DateTimePeriod period = DateTimePeriod.make(
+        LocalDateTime.of(2024, 1, 1, 9, 30),
+        LocalDateTime.of(2024, 1, 1, 17, 45),
+        Precision.MINUTE
+);
+
+List<DateTimePeriod> list = List.of(period, period, period);
+DateTimePeriodCollection collection = DateTimePeriodCollection.of(list);
+```
+
+Create an empty collection:
+
+```java
+DateTimePeriodCollection emptyCollection = DateTimePeriodCollection.empty();
+```
+
+Create an empty collection when given collection is `null`:
+
+```java
+DateTimePeriodCollection emptyCollection = DateTimePeriodCollection.emptyIfNull(null); // new empty instance
+DateTimePeriodCollection collection = DateTimePeriodCollection.emptyIfNull(DateTimePeriodCollection.of(period)); // return the given collection [period]
+```
+
+### `DateTimePeriodCollection overlapAll(DateTimePeriodCollection... collections)`
+
+Calculates the overlap of all periods across the given collections.
+
+![](./docs/images/collection-overlap-all.svg)
+
+```java
+DateTimePeriod a1 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-01-20")
+);
+DateTimePeriod a2 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-25"),
+        LocalDate.parse("2024-01-31")
+);
+DateTimePeriodCollection a = DateTimePeriodCollection.of(a1, a2);
+
+DateTimePeriodCollection b = DateTimePeriodCollection.of(DateTimePeriod.make(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-01-28")
+));
+
+DateTimePeriodCollection c = DateTimePeriodCollection.of(DateTimePeriod.make(
+        LocalDate.parse("2024-01-10"),
+        LocalDate.parse("2024-02-20")
+));
+
+DateTimePeriodCollection result = a.overlapAll(b, c);
+// result represents [[2024-01-10, 2024-01-20], [2024-01-25, 2024-01-28]]
+```
+
 ### Testing
 
 ```bash

--- a/docs/images/collection-overlap-all.svg
+++ b/docs/images/collection-overlap-all.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 250">
+  <rect x="0" y="0" width="400" height="250" fill="white" />
+
+  <!-- Timeline -->
+  <line x1="20" y1="200" x2="350" y2="200" stroke="black" stroke-width="2"/>
+
+  <!-- Time markers -->
+  <line x1="20" y1="195" x2="20" y2="205" stroke="black" stroke-width="2"/>
+  <line x1="350" y1="195" x2="350" y2="205" stroke="black" stroke-width="2"/>
+
+  <!-- Collection A -->
+  <text x="0" y="30" font-family="Verdana" font-size="9">A[]</text>
+  <!-- Period 1 -->
+  <rect x="20" y="35" width="130" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="25" y="55" font-family="Verdana" font-size="14" fill="white">Period A1</text>
+  <!-- Period 2 -->
+  <rect x="180" y="35" width="100" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="185" y="55" font-family="Verdana" font-size="14" fill="white">Period A2</text>
+
+  <!-- Collection B -->
+  <text x="0" y="80" font-family="Verdana" font-size="9">B[]</text>
+  <!-- Period 1 -->
+  <rect x="20" y="85" width="200" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="25" y="105" font-family="Verdana" font-size="14" fill="white">Period B1</text>
+
+  <!-- Collection C -->
+  <text x="0" y="130" font-family="Verdana" font-size="9">C[]</text>
+  <!-- Period 1 -->
+  <rect x="100" y="135" width="250" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="105" y="155" font-family="Verdana" font-size="14" fill="white">Period C1</text>
+
+  <!-- Overlap areas -->
+  <rect x="100" y="185" width="50" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <text x="105" y="205" font-family="Verdana" font-size="10" fill="white">Overlap</text>
+  <rect x="180" y="185" width="40" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <text x="182" y="205" font-family="Verdana" font-size="9" fill="white">Overlap</text>
+
+  <!-- Overlap indicators -->
+  <line x1="100" y1="65" x2="100" y2="215" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="150" y1="65" x2="150" y2="215" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="180" y1="65" x2="180" y2="215" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="220" y1="65" x2="220" y2="215" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+
+  <!-- Legend -->
+  <text x="20" y="230" font-family="Verdana" font-size="12">Start</text>
+  <text x="330" y="230" font-family="Verdana" font-size="12">End</text>
+</svg>

--- a/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollection.java
+++ b/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollection.java
@@ -56,6 +56,44 @@ public class DateTimePeriodCollection implements Collection<DateTimePeriod> {
         return collection != null ? collection : empty();
     }
 
+    /**
+     * Calculates the overlap of all periods across the given collections.
+     *
+     * @param collections to be considered for overlap
+     * @return A new collection containing periods that represent the common overlap across all
+     * input collections. If there is no common overlap, an empty collection is returned.
+     * @throws DateTimePeriodException if precision does not match
+     */
+    public DateTimePeriodCollection overlapAll(DateTimePeriodCollection... collections) {
+        DateTimePeriodCollection overlap = this;
+        for (DateTimePeriodCollection collection : collections) {
+            overlap = overlap.overlap(collection);
+        }
+        return overlap;
+    }
+
+    private DateTimePeriodCollection overlap(DateTimePeriodCollection collection) {
+        DateTimePeriodCollection overlaps = DateTimePeriodCollection.empty();
+        for (DateTimePeriod period : this) {
+            for (DateTimePeriod otherPeriod : collection) {
+                DateTimePeriod overlap = period.overlap(otherPeriod);
+                if (overlap == null) {
+                    continue;
+                }
+
+                overlaps.add(overlap);
+            }
+        }
+        return overlaps;
+    }
+
+    /**
+     * Returns the period at the specified position in this collection.
+     *
+     * @param index index of the element to return
+     * @return the period at the specified position in this collection
+     * @throws IndexOutOfBoundsException {@inheritDoc}
+     */
     public DateTimePeriod get(int index) {
         return this.data.get(index);
     }

--- a/src/test/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollectionTest.java
+++ b/src/test/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollectionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class DateTimePeriodCollectionTest {
@@ -34,5 +35,55 @@ class DateTimePeriodCollectionTest {
 
         // Then
         assertThat(result).isEqualTo("[[2024-01-01T00:00, 2024-01-20T00:00], [2024-03-01T00:00, 2024-03-31T00:00]]");
+    }
+
+    @Nested
+    class OverlapAll {
+
+        @Test
+        void shouldDetermineMultipleOverlapsForASingleCollection() {
+            // Given
+            DateTimePeriodCollection current = DateTimePeriodCollection.of(
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 5), LocalDate.of(2024, 1, 10)),
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 20), LocalDate.of(2024, 1, 25)));
+
+            DateTimePeriodCollection collection = DateTimePeriodCollection.of(
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 15)),
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 22), LocalDate.of(2024, 1, 31)));
+
+            // When
+            DateTimePeriodCollection result = current.overlapAll(collection);
+
+            // Then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0))
+                    .isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 5), LocalDate.of(2024, 1, 10)));
+            assertThat(result.get(1))
+                    .isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 22), LocalDate.of(2024, 1, 25)));
+        }
+
+        @Test
+        void shouldDetermineMultipleOverlapsForMultipleCollections() {
+            // Given
+            DateTimePeriodCollection current = DateTimePeriodCollection.of(
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 5), LocalDate.of(2024, 1, 7)),
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 25)));
+
+            DateTimePeriodCollection a = DateTimePeriodCollection.of(
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 20)));
+
+            DateTimePeriodCollection b = DateTimePeriodCollection.of(
+                    DateTimePeriod.make(LocalDate.of(2024, 1, 6), LocalDate.of(2024, 1, 20)));
+
+            // When
+            DateTimePeriodCollection result = current.overlapAll(a, b);
+
+            // Then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0))
+                    .isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 6), LocalDate.of(2024, 1, 7)));
+            assertThat(result.get(1))
+                    .isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 1, 20)));
+        }
     }
 }


### PR DESCRIPTION
## Description

Calculates the overlap of all periods across the given collections.

## Implementation

- New method to calculate the overlap of all periods across the given collections.
- Throws `DateTimePeriodException` when the precision does not match

## Usage Example

```java
DateTimePeriod a1 = DateTimePeriod.make(
        LocalDate.parse("2024-01-01"),
        LocalDate.parse("2024-01-20")
);
DateTimePeriod a2 = DateTimePeriod.make(
        LocalDate.parse("2024-01-25"),
        LocalDate.parse("2024-01-31")
);
DateTimePeriodCollection a = DateTimePeriodCollection.of(a1, a2);

DateTimePeriodCollection b = DateTimePeriodCollection.of(DateTimePeriod.make(
        LocalDate.parse("2024-01-01"),
        LocalDate.parse("2024-01-28")
));

DateTimePeriodCollection c = DateTimePeriodCollection.of(DateTimePeriod.make(
        LocalDate.parse("2024-01-10"),
        LocalDate.parse("2024-02-20")
));

DateTimePeriodCollection result = a.overlapAll(b, c);
// result represents [[2024-01-10, 2024-01-20], [2024-01-25, 2024-01-28]]
```
