### PR TITLE
Subtract two periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,28 @@ DateTimePeriod overlapAny = period1.overlapAny(period2, period3);
 // [[2024-01-05, 2024-01-10], [2024-01-20, 2024-01-25]]
 ```
 
+### `DateTimePeriodCollection subtract(DateTimePeriod period)`
+
+Subtracts a period from another period. It returns a collection containing the remaining
+non-overlapping periods.
+
+![](./docs/images/period-subtract.svg)
+
+```java
+DateTimePeriod period1 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-01"),
+        LocalDate.parse("2024-01-31")
+);
+
+DateTimePeriod period2 = DateTimePeriod.make(
+        LocalDate.parse("2024-01-15"),
+        LocalDate.parse("2024-01-20")
+);
+
+DateTimePeriodCollection subtract = period1.subtract(period2);
+// [[2024-01-01, 2024-01-14], [2024-01-21, 2024-01-31]]
+```
+
 ---
 
 The `DateTimePeriodCollection` methods:
@@ -318,8 +340,10 @@ DateTimePeriodCollection emptyCollection = DateTimePeriodCollection.empty();
 Create an empty collection when given collection is `null`:
 
 ```java
-DateTimePeriodCollection emptyCollection = DateTimePeriodCollection.emptyIfNull(null); // new empty instance
-DateTimePeriodCollection collection = DateTimePeriodCollection.emptyIfNull(DateTimePeriodCollection.of(period)); // return the given collection [period]
+DateTimePeriodCollection emptyCollection = DateTimePeriodCollection.emptyIfNull(
+        null); // new empty instance
+DateTimePeriodCollection collection = DateTimePeriodCollection.emptyIfNull(
+        DateTimePeriodCollection.of(period)); // return the given collection [period]
 ```
 
 ### `DateTimePeriodCollection overlapAll(DateTimePeriodCollection... collections)`

--- a/docs/images/period-subtract.svg
+++ b/docs/images/period-subtract.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 520">
+  <rect x="0" y="0" width="400" height="520" fill="white" />
+
+
+  <!-- Divider -->
+  <line x1="0" y1="250" x2="400" y2="250" stroke="#ccc" stroke-width="1" stroke-dasharray="1"/>
+
+  <!-- ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+  <!-- Example 1 -->
+  <!-- ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+  <!-- Timeline -->
+  <line x1="20" y1="200" x2="350" y2="200" stroke="black" stroke-width="2"/>
+
+  <!-- Time markers -->
+  <line x1="20" y1="195" x2="20" y2="205" stroke="black" stroke-width="2"/>
+  <line x1="350" y1="195" x2="350" y2="205" stroke="black" stroke-width="2"/>
+
+  <!-- Period A -->
+  <rect x="60" y="35" width="250" height="30" fill="#9f86c0" stroke="#5e548e" stroke-width="2"/>
+  <text x="70" y="55" font-family="Verdana" font-size="14" fill="white">Period A</text>
+
+  <!-- Period B -->
+  <rect x="120" y="85" width="80" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="130" y="105" font-family="Verdana" font-size="14"  fill="white">Period B</text>
+
+  <!-- Subtract areas -->
+  <rect x="60" y="185" width="60" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <text x="65" y="205" font-family="Verdana" font-size="11" fill="white">Subtract</text>
+  <rect x="200" y="185" width="110" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <text x="210" y="205" font-family="Verdana" font-size="14" fill="white">Subtract</text>
+
+  <!-- Subtract indicators -->
+  <line x1="60" y1="65" x2="60" y2="185" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="120" y1="65" x2="120" y2="185" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="200" y1="65" x2="200" y2="185" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="310" y1="65" x2="310" y2="185" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+
+  <!-- Legend -->
+  <text x="20" y="230" font-family="Verdana" font-size="12">Start</text>
+  <text x="330" y="230" font-family="Verdana" font-size="12">End</text>
+  <!-- ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+
+  <!-- ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+  <!-- Example 2 -->
+  <!-- ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+  <!-- Timeline -->
+  <line x1="20" y1="470" x2="350" y2="470" stroke="black" stroke-width="2"/>
+
+  <!-- Time markers -->
+  <line x1="20" y1="465" x2="20" y2="475" stroke="black" stroke-width="2"/>
+  <line x1="350" y1="465" x2="350" y2="475" stroke="black" stroke-width="2"/>
+
+  <!-- Period A -->
+  <rect x="200" y="285" width="160" height="30" fill="#9f86c0" stroke="#5e548e" stroke-width="2"/>
+  <text x="210" y="305" font-family="Verdana" font-size="14" fill="white">Period A</text>
+
+  <!-- Period B -->
+  <rect x="20" y="335" width="220" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="30" y="355" font-family="Verdana" font-size="14" fill="white">Period B</text>
+
+  <!-- Period C -->
+  <rect x="150" y="385" width="150" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="160" y="405" font-family="Verdana" font-size="14" fill="white">Period C</text>
+
+  <!-- Subtract areas -->
+  <rect x="300" y="455" width="60" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <text x="305" y="475" font-family="Verdana" font-size="11" fill="white">Subtract</text>
+
+  <!-- Subtract indicators -->
+  <line x1="300" y1="315" x2="300" y2="455" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="360" y1="315" x2="360" y2="455" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+
+  <!-- Legend -->
+  <text x="20" y="500" font-family="Verdana" font-size="12">Start</text>
+  <text x="330" y="500" font-family="Verdana" font-size="12">End</text>
+</svg>

--- a/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriod.java
+++ b/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriod.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
-public class DateTimePeriod implements Serializable, Cloneable, Comparable<DateTimePeriod> {
+public class DateTimePeriod implements Serializable, Comparable<DateTimePeriod> {
 
     private final LocalDateTime start;
     private final LocalDateTime end;
@@ -223,6 +223,35 @@ public class DateTimePeriod implements Serializable, Cloneable, Comparable<DateT
             overlaps.add(overlap);
         }
         return overlaps;
+    }
+
+    /**
+     * Subtracts the given period from this period, returning a new collection containing the
+     * remaining non-overlapping periods.
+     *
+     * @param period to be subtracted from this period
+     * @return A collection containing the remaining periods after subtraction
+     * @throws DateTimePeriodException if precision does not match
+     */
+    public DateTimePeriodCollection subtract(DateTimePeriod period) {
+        this.ensurePrecisionMatches(period);
+
+        if (!this.overlapsWith(period)) {
+            return DateTimePeriodCollection.of(this);
+        }
+
+        DateTimePeriodCollection collection = DateTimePeriodCollection.empty();
+        if (this.start().isBefore(period.start())) {
+            collection.add(DateTimePeriod.make(
+                    this.start(), period.start().minus(this.precision().interval()), this.precision()));
+        }
+
+        if (this.end().isAfter(period.end())) {
+            collection.add(
+                    DateTimePeriod.make(period.end().plus(this.precision().interval()), this.end(), this.precision()));
+        }
+
+        return collection;
     }
 
     /**


### PR DESCRIPTION
## Description

Subtracts a period from another period. It returns a collection containing the remaining
non-overlapping periods.

## Implementation

- New method to subtract a period from another period. It returns a collection containing the remaining
non-overlapping periods.
- Throws `DateTimePeriodException` when the precision does not match

## Usage Example

```java
DateTimePeriod period1 = DateTimePeriod.make(
        LocalDate.parse("2024-01-01"),
        LocalDate.parse("2024-01-31")
);

DateTimePeriod period2 = DateTimePeriod.make(
        LocalDate.parse("2024-01-15"),
        LocalDate.parse("2024-01-20")
);

DateTimePeriodCollection subtract = period1.subtract(period2);
// [[2024-01-01, 2024-01-14], [2024-01-21, 2024-01-31]]
```
