### PR TITLE
Intersection between a collection and a period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ All notable changes to `datetimeperiod` will be documented in this file
 ## 0.1.0 - 202X-XX-XX
 
 - Initial test release
+

--- a/README.md
+++ b/README.md
@@ -481,6 +481,28 @@ DateTimePeriodCollection gaps = a.gaps();
 // gaps represents [[2024-01-11, 2024-01-14], [2024-01-21, 2024-01-24]]
 ```
 
+### `DateTimePeriodCollection intersect(DateTimePeriod intersection)`
+
+Calculate the intersection between a collection and a period.
+
+![](./docs/images/collection-intersect.svg)
+
+```java
+DateTimePeriodCollection collection = DateTimePeriodCollection.of(
+        DateTimePeriod.make(LocalDate.parse("2024-01-05"), LocalDate.parse("2024-01-15")),
+        DateTimePeriod.make(LocalDate.parse("2024-01-°1"), LocalDate.parse("2024-01-10")),
+        DateTimePeriod.make(LocalDate.parse("2024-01-10"), LocalDate.parse("2024-01-15")),
+        DateTimePeriod.make(LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-15")));
+
+DateTimePeriod intersection = DateTimePeriod.make(
+        LocalDate.parse("2024-01-09"), 
+        LocalDate.parse("2024-01-11")
+);
+
+DateTimePeriodCollection result = collection.intersect(intersection);
+// result represents [[2024-01-09, 2024-01-11], [2024-01-09, 2024-01-10], [2024-01-10, 2024-01-11]]
+```
+
 ### Testing
 
 ```bash

--- a/docs/images/collection-intersect.svg
+++ b/docs/images/collection-intersect.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 500">
+  <rect x="0" y="0" width="400" height="500" fill="white" />
+
+  <!-- Timeline -->
+  <line x1="20" y1="450" x2="350" y2="450" stroke="black" stroke-width="2"/>
+
+  <!-- Time markers -->
+  <line x1="20" y1="445" x2="20" y2="455" stroke="black" stroke-width="2"/>
+  <line x1="350" y1="445" x2="350" y2="455" stroke="black" stroke-width="2"/>
+
+  <!-- Period 1 -->
+  <rect x="10" y="35" width="80" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="15" y="55" font-family="Verdana" font-size="14" fill="white">Period 1</text>
+  <!-- Period 2 -->
+  <rect x="100" y="85" width="150" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="105" y="105" font-family="Verdana" font-size="14" fill="white">Period 2</text>
+  <!-- Period 3 -->
+  <rect x="200" y="135" width="150" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="205" y="155" font-family="Verdana" font-size="14" fill="white">Period 3</text>
+  <!-- Period 4 -->
+  <rect x="40" y="185" width="150" height="30" fill="#f4a261" stroke="#e76f51" stroke-width="2"/>
+  <text x="45" y="205" font-family="Verdana" font-size="14" fill="white">Period 4</text>
+  <!-- Period 5 -->
+  <rect x="120" y="235" width="200" height="30" fill="#9f86c0" stroke="#5e548e" stroke-width="2"/>
+  <text x="125" y="255" font-family="Verdana" font-size="14" fill="white">Intersect Period</text>
+
+
+  <!-- Intersection areas -->
+  <rect x="120" y="285" width="130" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <rect x="200" y="335" width="120" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+  <rect x="120" y="385" width="70" height="30" fill="#2a9d8f" stroke="#264653" stroke-width="2"/>
+
+  <!-- Intersection indicators -->
+  <line x1="120" y1="115" x2="120" y2="285" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="250" y1="115" x2="250" y2="285" stroke="#264653" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="200" y1="165" x2="200" y2="335" stroke="blue" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="320" y1="165" x2="320" y2="335" stroke="blue" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="120" y1="215" x2="120" y2="385" stroke="red" stroke-width="2" stroke-dasharray="4"/>
+  <line x1="190" y1="215" x2="190" y2="385" stroke="red" stroke-width="2" stroke-dasharray="4"/>
+
+  <!-- Legend -->
+  <text x="20" y="470" font-family="Verdana" font-size="12">Start</text>
+  <text x="330" y="470" font-family="Verdana" font-size="12">End</text>
+</svg>

--- a/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollection.java
+++ b/src/main/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollection.java
@@ -119,6 +119,7 @@ public class DateTimePeriodCollection implements Collection<DateTimePeriod> {
      *
      * @param periods to be subtracted from this collection
      * @return A new collection containing the remaining periods after subtraction
+     * @throws DateTimePeriodException if precision does not match
      */
     public DateTimePeriodCollection subtract(DateTimePeriod... periods) {
         if (periods.length == 0) {
@@ -138,6 +139,7 @@ public class DateTimePeriodCollection implements Collection<DateTimePeriod> {
      *
      * @param collection to be subtracted from this collection
      * @return A new collection containing the remaining periods after subtraction
+     * @throws DateTimePeriodException if precision does not match
      */
     public DateTimePeriodCollection subtract(DateTimePeriodCollection collection) {
         if (collection.size() == 0) {
@@ -153,6 +155,7 @@ public class DateTimePeriodCollection implements Collection<DateTimePeriod> {
      * @return A new collection containing periods that represent the time gaps between the periods
      * in this collection. If there are no gaps (i.e., all periods are contiguous or overlapping),
      * returns an empty collection.
+     * @throws DateTimePeriodException if precision does not match
      */
     public DateTimePeriodCollection gaps() {
         DateTimePeriod boundaries = this.boundaries();
@@ -161,6 +164,29 @@ public class DateTimePeriodCollection implements Collection<DateTimePeriod> {
         }
 
         return boundaries.subtractAll(this.toArray(new DateTimePeriod[0]));
+    }
+
+    /**
+     * Calculates the intersection of this collection with the given period.
+     *
+     * @param intersection The DateTimePeriod to intersect with this collection
+     * @return A new collection containing periods that represent the intersection of each period in
+     * this collection with the given period. Periods that don't intersect are excluded from the
+     * result.
+     * @throws DateTimePeriodException if precision does not match
+     */
+    public DateTimePeriodCollection intersect(DateTimePeriod intersection) {
+        DateTimePeriodCollection intersected = DateTimePeriodCollection.empty();
+
+        for (DateTimePeriod period : this) {
+            DateTimePeriod overlap = intersection.overlap(period);
+            if (overlap == null) {
+                continue;
+            }
+            intersected.add(overlap);
+        }
+
+        return intersected;
     }
 
     /**

--- a/src/test/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollectionTest.java
+++ b/src/test/java/dev/nextgin/commons/datetimeperiod/DateTimePeriodCollectionTest.java
@@ -36,6 +36,26 @@ class DateTimePeriodCollectionTest {
         assertThat(result).isEqualTo("[[2024-01-01T00:00, 2024-01-20T00:00], [2024-03-01T00:00, 2024-03-31T00:00]]");
     }
 
+    @Test
+    void intersect() {
+        // Given
+        DateTimePeriodCollection collection = DateTimePeriodCollection.of(
+                DateTimePeriod.make(LocalDate.of(2024, 1, 5), LocalDate.of(2024, 1, 15)),
+                DateTimePeriod.make(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 10)),
+                DateTimePeriod.make(LocalDate.of(2024, 1, 10), LocalDate.of(2024, 1, 15)),
+                DateTimePeriod.make(LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 15)));
+        DateTimePeriod intersection = DateTimePeriod.make(LocalDate.of(2024, 1, 9), LocalDate.of(2024, 1, 11));
+
+        // When
+        DateTimePeriodCollection result = collection.intersect(intersection);
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 9), LocalDate.of(2024, 1, 11)));
+        assertThat(result.get(1)).isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 9), LocalDate.of(2024, 1, 10)));
+        assertThat(result.get(2)).isEqualTo(DateTimePeriod.make(LocalDate.of(2024, 1, 10), LocalDate.of(2024, 1, 11)));
+    }
+
     @Nested
     class OverlapAll {
 


### PR DESCRIPTION
## Description

Calculate the intersection between a collection and a period.

## Implementation

- New method to calculate the intersection between a collection of periods and a given period.
- Throws `DateTimePeriodException` when the precision does not match

## Usage Example

```java
DateTimePeriodCollection collection = DateTimePeriodCollection.of(
        DateTimePeriod.make(LocalDate.parse("2024-01-05"), LocalDate.parse("2024-01-15")),
        DateTimePeriod.make(LocalDate.parse("2024-01-°1"), LocalDate.parse("2024-01-10")),
        DateTimePeriod.make(LocalDate.parse("2024-01-10"), LocalDate.parse("2024-01-15")),
        DateTimePeriod.make(LocalDate.parse("2024-02-01"), LocalDate.parse("2024-02-15")));

DateTimePeriod intersection = DateTimePeriod.make(
        LocalDate.parse("2024-01-09"), 
        LocalDate.parse("2024-01-11")
);

DateTimePeriodCollection result = collection.intersect(intersection);
// result represents [[2024-01-09, 2024-01-11], [2024-01-09, 2024-01-10], [2024-01-10, 2024-01-11]]
```
